### PR TITLE
Add startup initialization check for proper installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,32 @@ The theme used in the recording is [lighthaus.nvim](https://github.com/mrjones20
 
 Note: Dash is a Mac-only app, so you'll only find this plugin useful on Mac.
 
+## Install
+
+After installing Dash.nvim, you must run `make install`. This can be done through a post-install hook with most plugin managers.
+
+Packer:
+
+```lua
+use({ 'mrjones2014/dash.nvim', requires = { 'nvim-telescope/telescope.nvim' }, run = 'make install' })
+```
+
+Paq:
+
+```lua
+require("paq")({
+  'nvim-telescope/telescope.nvim';
+  {'mrjones2014/dash.nvim', run = 'make install'}
+})
+```
+
+Vim-Plug:
+
+```VimL
+Plug 'nvim-telescope/telescope.nvim'
+Plug 'mrjones2014/dash.nvim', { 'do': 'make install' }
+```
+
 ## Usage
 
 <!-- panvimdoc-ignore-start -->
@@ -35,33 +61,6 @@ will search without this keyword filtering.
 `:Dash [query]` will open the Telescope picker, and if `[query]` is passed, it will pre-fill the prompt with `[query]`.
 
 `:DashWord` will open the Telescope picker and pre-fill the prompt with the word under the cursor.
-
-### Lua API
-
-The public API consists of two main functions.
-
-```lua
--- See lua/dash.config.lua for full DashConfig type definition
--- Also described in configuration section below
----@param config DashConfig
-require('dash').setup(config)
-```
-
-```lua
----@param bang boolean @bang searches without any filtering
----@param initial_text string @pre-fill text into the telescope picker
-require('dash').search(bang, initial_text)
-```
-
-See [backend](#Backend) for documentation on the backend data provider.
-
-## Install
-
-Using Packer:
-
-```lua
-use({ 'mrjones2014/dash.nvim', requires = { 'nvim-telescope/telescope.nvim' }, run = 'make install' })
-```
 
 ## Configuration
 
@@ -102,6 +101,25 @@ require('telescope').setup({
 ```
 
 If you notice an issue with the default `file_type_keywords` or would like a new filetype added, please file an issue or submit a PR!
+
+### Lua API
+
+The public API consists of two main functions.
+
+```lua
+-- See lua/dash.config.lua for full DashConfig type definition
+-- Also described in configuration section below
+---@param config DashConfig
+require('dash').setup(config)
+```
+
+```lua
+---@param bang boolean @bang searches without any filtering
+---@param initial_text string @pre-fill text into the telescope picker
+require('dash').search(bang, initial_text)
+```
+
+See [backend](#Backend) for documentation on the backend data provider.
 
 ## Backend
 

--- a/lua/dash/startup.lua
+++ b/lua/dash/startup.lua
@@ -1,0 +1,20 @@
+local M = {}
+
+function M.init()
+  -- check if `make install` was run
+  local ok, libdash = pcall(require, 'libdash_nvim')
+  if not ok or libdash == nil then
+    vim.api.nvim_err_writeln(
+      'module "libdash_nvim" not found, did you set up Dash.nvim with `make install` as a post-install hook?'
+        .. ' See :h dash-install'
+    )
+    return
+  end
+
+  require('telescope._extensions.dash')
+  require('telescope').load_extension('dash')
+
+  vim.g.loaded_dash_vim = true
+end
+
+return M

--- a/plugin/dash.vim
+++ b/plugin/dash.vim
@@ -12,7 +12,4 @@ endfunction
 command! -nargs=* -bang Dash :call <SID>dash_nvim_search(<bang>0, <q-args>)
 command! -nargs=0 -bang DashWord :call <SID>dash_nvim_search(<bang>0, expand('<cword>'))
 
-lua require('telescope._extensions.dash')
-lua require('telescope').load_extension('dash')
-
-let g:loaded_dash_nvim = 1
+lua require('dash.startup').init()


### PR DESCRIPTION
Resolves #63 

Checks if `libdash_nvim` is available via `pcall` and if not, prints an error that the user probably forgot to do `make install`.