### PR TITLE
Update packer install instructions to disable when not on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ After installing Dash.nvim, you must run `make install`. This can be done throug
 Packer:
 
 ```lua
-use({ 'mrjones2014/dash.nvim', requires = { 'nvim-telescope/telescope.nvim' }, run = 'make install' })
+use({
+  'mrjones2014/dash.nvim',
+  requires = { 'nvim-telescope/telescope.nvim' },
+  run = 'make install',
+  disable = not vim.fn.has('macunix'),
+})
 ```
 
 Paq:


### PR DESCRIPTION
This is a simple change to disable the plugin when not on macOS for users that have their config on multiple machines with different operating systems.